### PR TITLE
Make prepare.sh abort on first error.

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 export LC_ALL=C
 export LANG=C
 


### PR DESCRIPTION
The script shouldn't be able to continue with a missing command or a
failure to download Oracle JDK.
